### PR TITLE
Add patch for linking to libiconv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,12 @@ source:
     - {{ cran_mirror }}/src/contrib/haven_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/haven/haven_{{ version }}.tar.gz
   sha256: 90bcb4e7f24960e7aa3e15c06b95cd897f08de149cec43fd8ba110b14526068a
+  patches:
+    - r-haven-libiconv.patch
 
 build:
   merge_build_host: True  # [win]
-  number: 2
+  number: 3
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipe/r-haven-libiconv.patch
+++ b/recipe/r-haven-libiconv.patch
@@ -1,0 +1,8 @@
+--- src/Makevars.orig	2019-09-15 09:14:58.833433857 +0200
++++ src/Makevars	2019-09-15 09:15:09.469235085 +0200
+@@ -8,4 +8,4 @@
+ 
+ PKG_CFLAGS = -Ireadstat -DHAVE_ZLIB
+ PKG_CXXFLAGS = -Ireadstat -DHAVE_ZLIB
+-PKG_LIBS = -lz
++PKG_LIBS = -lz -liconv


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
